### PR TITLE
Implement Post status

### DIFF
--- a/.idea/assetWizardSettings.xml
+++ b/.idea/assetWizardSettings.xml
@@ -142,6 +142,43 @@
             </PersistentState>
           </value>
         </entry>
+        <entry key="vectorWizard">
+          <value>
+            <PersistentState>
+              <option name="children">
+                <map>
+                  <entry key="vectorAssetStep">
+                    <value>
+                      <PersistentState>
+                        <option name="children">
+                          <map>
+                            <entry key="clipartAsset">
+                              <value>
+                                <PersistentState>
+                                  <option name="values">
+                                    <map>
+                                      <entry key="url" value="jar:file:/home/peter/.local/share/JetBrains/Toolbox/apps/AndroidStudio/ch-0/193.6626763/plugins/android/lib/android.jar!/images/material/icons/materialicons/description/baseline_description_24.xml" />
+                                    </map>
+                                  </option>
+                                </PersistentState>
+                              </value>
+                            </entry>
+                          </map>
+                        </option>
+                        <option name="values">
+                          <map>
+                            <entry key="color" value="424242" />
+                            <entry key="outputName" value="ic_baseline_draft_24" />
+                          </map>
+                        </option>
+                      </PersistentState>
+                    </value>
+                  </entry>
+                </map>
+              </option>
+            </PersistentState>
+          </value>
+        </entry>
       </map>
     </option>
   </component>

--- a/app/src/main/java/eu/stuifzand/micropub/MainActivity.java
+++ b/app/src/main/java/eu/stuifzand/micropub/MainActivity.java
@@ -167,6 +167,14 @@ public class MainActivity extends AppCompatActivity {
                 inputManager.hideSoftInputFromInputMethod(this.getCurrentFocus().getWindowToken(), 0);
             }
             galleryIntent(null);
+        } else if (id == R.id.action_save_draft) {
+            InputMethodManager inputManager = (InputMethodManager) this.getSystemService(Context.INPUT_METHOD_SERVICE);
+            if (this.getCurrentFocus() != null && inputManager != null) {
+                inputManager.hideSoftInputFromWindow(this.getCurrentFocus().getWindowToken(), 0);
+                inputManager.hideSoftInputFromInputMethod(this.getCurrentFocus().getWindowToken(), 0);
+            }
+            postModel.postStatus.set("draft");
+            sendPost(null);
         }
 
         return super.onOptionsItemSelected(item);

--- a/app/src/main/java/eu/stuifzand/micropub/PostViewModel.java
+++ b/app/src/main/java/eu/stuifzand/micropub/PostViewModel.java
@@ -29,6 +29,7 @@ public class PostViewModel extends ViewModel {
     public final ObservableField<String> photo = new ObservableField<>();
     public final ObservableField<String> likeOf = new ObservableField<>();
     public final ObservableField<String> bookmarkOf = new ObservableField<>();
+    public final ObservableField<String> postStatus = new ObservableField<>();
 
     public PostViewModel() {
         this.name.set("");
@@ -38,6 +39,7 @@ public class PostViewModel extends ViewModel {
         this.photo.set("");
         this.likeOf.set("");
         this.bookmarkOf.set("");
+        this.postStatus.set("");
     }
 
     public void clear() {
@@ -48,6 +50,7 @@ public class PostViewModel extends ViewModel {
         this.photo.set("");
         this.likeOf.set("");
         this.bookmarkOf.set("");
+        this.postStatus.set("");
     }
 
     public void findReplyTo(String urlOrNote) {
@@ -95,6 +98,9 @@ public class PostViewModel extends ViewModel {
         }
         if (!this.bookmarkOf.get().equals("")) {
             post.setBookmarkOf(HttpUrl.parse(bookmarkOf.get()));
+        }
+        if (!this.postStatus.get().equals("")) {
+            post.setPostStatus((postStatus.get()));
         }
         return post;
     }

--- a/app/src/main/java/eu/stuifzand/micropub/client/Post.java
+++ b/app/src/main/java/eu/stuifzand/micropub/client/Post.java
@@ -12,6 +12,7 @@ public class Post {
     private HttpUrl likeOf;
     private HttpUrl bookmarkOf;
     private String[] destinationUids;
+    private String postStatus;
 
     public Post(String content) {
         if (content.equals("")) {
@@ -107,6 +108,17 @@ public class Post {
 
     public boolean hasContent() {
         return content != null;
+    }
+
+    public boolean hasPostStatus() { return postStatus != null; }
+
+    public String getPostStatus() { return postStatus; }
+
+    /**
+     * @param postStatus "published"|"draft"
+     */
+    public void setPostStatus(String postStatus) {
+        this.postStatus = postStatus;
     }
 
     public void setBookmarkOf(HttpUrl bookmarkOf) {

--- a/app/src/main/java/eu/stuifzand/micropub/client/PostTask.java
+++ b/app/src/main/java/eu/stuifzand/micropub/client/PostTask.java
@@ -67,6 +67,11 @@ class PostTask extends AsyncTask<String, Void, Void> {
         if (post.hasBookmarkOf()) {
             builder.add("bookmark-of[]", post.getBookmarkOf());
         }
+
+        if (post.hasPostStatus()) {
+            builder.add("post-status", post.getPostStatus());
+        }
+
         RequestBody formBody = builder.build();
 
         Request request = new Request.Builder()

--- a/app/src/main/res/drawable/ic_baseline_draft_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_draft_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#424242"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M14,2L6,2c-1.1,0 -1.99,0.9 -1.99,2L4,20c0,1.1 0.89,2 1.99,2L18,22c1.1,0 2,-0.9 2,-2L20,8l-6,-6zM16,18L8,18v-2h8v2zM16,14L8,14v-2h8v2zM13,9L13,3.5L18.5,9L13,9z"/>
+</vector>

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -10,12 +10,20 @@
         android:orderInCategory="10"
         android:title="@string/action_photo"
         app:showAsAction="ifRoom" />
-
+    <item
+        android:id="@+id/action_save_draft"
+        android:checkable="false"
+        android:enabled="true"
+        android:icon="@drawable/ic_baseline_draft_24"
+        android:orderInCategory="20"
+        android:title="@string/save_draft"
+        android:visible="true"
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/action_send"
         android:enabled="true"
         android:icon="@drawable/ic_send"
-        android:orderInCategory="10"
+        android:orderInCategory="100"
         android:title="@string/action_send"
         app:showAsAction="always" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,4 +24,5 @@
     <string name="like_failed">Like failed</string>
     <string name="url_bookmarked">URL bookmarked</string>
     <string name="url_bookmark_failed">Failed to bookmark URL</string>
+    <string name="save_draft">Save draft</string>
 </resources>

--- a/app/src/test/java/eu/stuifzand/micropub/PostViewModelTest.java
+++ b/app/src/test/java/eu/stuifzand/micropub/PostViewModelTest.java
@@ -5,7 +5,10 @@ import org.junit.Test;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import eu.stuifzand.micropub.client.Post;
+
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 
 public class PostViewModelTest {
@@ -24,5 +27,26 @@ public class PostViewModelTest {
         assertTrue(matcher.find());
         String group = matcher.group(1);
         assertEquals(url, group);
+    }
+
+    /**
+     * The default post status is not set.
+     */
+    @Test
+    public void postStatusNotSet() {
+        PostViewModel postModel = new PostViewModel();
+        Post post = postModel.getPost();
+        assertFalse(post.hasPostStatus());
+    }
+
+    /**
+     * When the post status is set we should get with getPost.
+     */
+    @Test
+    public void postStatusSetToDraft() {
+        PostViewModel postModel = new PostViewModel();
+        postModel.postStatus.set("draft");
+        Post post = postModel.getPost();
+        assertEquals("draft", post.getPostStatus());
     }
 }


### PR DESCRIPTION
This PR adds an implementation of post-status.

A save as draft button is added. When clicked the `post-status` is set to `draft` and send as a micropub post to the micropub endpoint.